### PR TITLE
fix(selector): Updating the title for the file selector

### DIFF
--- a/cmd_add.go
+++ b/cmd_add.go
@@ -67,7 +67,8 @@ func (a *addCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) s
 		availableFiles = append(availableFiles, file.Name())
 	}
 
-	selector := newFileSelector(availableFiles)
+	const title = "Select a file to add to start tracking"
+	selector := newFileSelector(title, availableFiles)
 	choice, err := selector.Exec()
 	if err != nil {
 		slog.Error("Error selecting file", slog.String(loggingKeyError, err.Error()))

--- a/file_selector.go
+++ b/file_selector.go
@@ -11,6 +11,7 @@ import (
 )
 
 type fileSelector struct {
+	title   string
 	choices []string
 
 	cursor int
@@ -52,7 +53,7 @@ func (m *fileSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *fileSelector) View() string {
 	s := strings.Builder{}
-	s.WriteString("What kind of Bubble Tea would you like to order?\n\n")
+	s.WriteString(m.title + "\n\n")
 
 	for i := 0; i < len(m.choices); i++ {
 		if m.cursor == i {
@@ -76,6 +77,9 @@ func (m *fileSelector) Exec() (string, error) {
 	return m.choice, nil
 }
 
-func newFileSelector(files []string) fileSelector {
-	return fileSelector{choices: files}
+func newFileSelector(title string, files []string) fileSelector {
+	return fileSelector{
+		title:   title,
+		choices: files,
+	}
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to enhance the file selection process by adding a title to the file selector. The most important changes include the introduction of a title parameter in the `fileSelector` struct and updating the related methods to utilize this new parameter.

Enhancements to file selection:

* [`cmd_add.go`](diffhunk://#diff-0203908bf5d18762420c9d2147ce9a55009fcd1551ee1ccfea6133b703700137L70-R71): Modified the `newFileSelector` call to include a title parameter when creating a file selector.
* [`file_selector.go`](diffhunk://#diff-a8d70cf51f02d82a5997d68e0be45626a05953ada70b7c7f081d77777c4d7a1bR14): Added a `title` field to the `fileSelector` struct.
* [`file_selector.go`](diffhunk://#diff-a8d70cf51f02d82a5997d68e0be45626a05953ada70b7c7f081d77777c4d7a1bL55-R56): Updated the `View` method to display the title at the top of the file selector interface.
* [`file_selector.go`](diffhunk://#diff-a8d70cf51f02d82a5997d68e0be45626a05953ada70b7c7f081d77777c4d7a1bL79-R84): Modified the `newFileSelector` function to accept a title parameter and initialize the `fileSelector` struct with it.