### PR TITLE
chore(cicd): adding additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,137 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.

--- a/cmd_add.go
+++ b/cmd_add.go
@@ -29,7 +29,7 @@ func (a *addCmd) Usage() string {
 
 func (a *addCmd) SetFlags(f *flag.FlagSet) {}
 
-func (a *addCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (a *addCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	// Get the dotfiles in the local directory that have the `dot_` prefix.
 	// We are assuming that the user is running this command from the root of their repository.
 
@@ -56,15 +56,16 @@ func (a *addCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) s
 
 	availableFiles := make([]string, 0)
 	for _, file := range files {
-		if file.IsDir() {
+		switch {
+		case file.IsDir():
 			continue
-		} else if !strings.HasPrefix(file.Name(), ".") {
+		case !strings.HasPrefix(file.Name(), "."):
 			continue
-		} else if strings.HasSuffix(file.Name(), ".tmp") {
+		case strings.HasSuffix(file.Name(), ".tmp"):
 			continue
+		default:
+			availableFiles = append(availableFiles, file.Name())
 		}
-
-		availableFiles = append(availableFiles, file.Name())
 	}
 
 	const title = "Select a file to add to start tracking"

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -30,7 +30,7 @@ func (d *diffCmd) Usage() string {
 
 func (d *diffCmd) SetFlags(f *flag.FlagSet) {}
 
-func (d *diffCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (d *diffCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	// Get the dotfiles in the local directory that have the `dot_` prefix.
 	// We are assuming that the user is running this command from the root of their repository.
 

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -29,7 +29,7 @@ func (p *pullCmd) Usage() string {
 
 func (p *pullCmd) SetFlags(f *flag.FlagSet) {}
 
-func (p *pullCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (p *pullCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	// Get the dotfiles in the local directory that have the `dot_` prefix.
 	// We are assuming that the user is running this command from the root of their repository.
 

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -29,7 +29,7 @@ func (p *pushCmd) Usage() string {
 
 func (p *pushCmd) SetFlags(f *flag.FlagSet) {}
 
-func (p *pushCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (p *pushCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	// Get the dotfiles in the local directory that have the `dot_` prefix.
 	// We are assuming that the user is running this command from the root of their repository.
 

--- a/cmd_version.go
+++ b/cmd_version.go
@@ -33,7 +33,7 @@ func (v versionCmd) Usage() string {
 
 func (v versionCmd) SetFlags(f *flag.FlagSet) {}
 
-func (v versionCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (v versionCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	fmt.Printf(
 		"Commit: %s\nRuntime: %s %s/%s\nDate: %s\n",
 		Commit,

--- a/file_selector.go
+++ b/file_selector.go
@@ -23,8 +23,7 @@ func (m *fileSelector) Init() tea.Cmd {
 }
 
 func (m *fileSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
+	if msg, ok := msg.(tea.KeyMsg); ok {
 		switch msg.String() {
 		case "ctrl+c", "q", "esc":
 			return m, tea.Quit

--- a/main.go
+++ b/main.go
@@ -36,5 +36,5 @@ func main() {
 		cancel()
 	}()
 
-	os.Exit(int(subcommands.Execute(ctx)))
+	os.Exit(int(subcommands.Execute(ctx))) // nolint:gocritic // This is the main entry point for the application
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes aimed at improving code quality and consistency across the project. The most important changes include the addition of new linters and linter settings in the configuration file, refactoring of some functions to use Go's `any` type instead of `interface{}`, and minor code simplifications.

Improvements to code quality:

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R1-R137): Added multiple linters and detailed linter settings to enforce code quality and consistency.

Refactoring for type consistency:

* `cmd_add.go`, `cmd_diff.go`, `cmd_pull.go`, `cmd_push.go`, `cmd_version.go`: Updated the `Execute` methods to use the `any` type instead of `interface{}`. [[1]](diffhunk://#diff-0203908bf5d18762420c9d2147ce9a55009fcd1551ee1ccfea6133b703700137L32-R32) [[2]](diffhunk://#diff-3681ad4c4309c7f7a4b699f52f1a291fa1f7c08061cfb2a50ed95cd4ed9009e5L33-R33) [[3]](diffhunk://#diff-bc71d63ec325f5efa2edd9badebe7453e633e9578396c9bce15d30b281f41cc4L32-R32) [[4]](diffhunk://#diff-93042b7fa179061ac6c82160bfd3a0bbd320852439d1e7568699b9d459eddc61L32-R32) [[5]](diffhunk://#diff-3d9eaa84bc047869a6d484f31b36b41fe8b61d5df823caf977fb35715f639779L36-R36)

Code simplification:

* [`cmd_add.go`](diffhunk://#diff-0203908bf5d18762420c9d2147ce9a55009fcd1551ee1ccfea6133b703700137L59-R69): Refactored the `Execute` method to use a `switch` statement for better readability and maintainability.
* [`file_selector.go`](diffhunk://#diff-a8d70cf51f02d82a5997d68e0be45626a05953ada70b7c7f081d77777c4d7a1bL26-R26): Simplified the `Update` method by using a type assertion.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L39-R39): Added a `nolint` comment to suppress the `gocritic` linter warning for the main entry point of the application.