### PR TITLE
chore(linters): apply linter changes

### DIFF
--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -72,7 +72,7 @@ func (p *pullCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcomma
 		slog.Info("Copying file", slog.String(loggingKeyFile, homeDotName))
 
 		// Copy the contents of the home dotfile to the repository dotfile.
-		if err := copyFile(homeDotPath, repoDot); err != nil {
+		if err := copyFile(homeDotPath, repoDot); err != nil { // nolint:revive // This is valid and traditional error handling
 			slog.Error("Error copying file", slog.String(loggingKeyError, err.Error()))
 			return subcommands.ExitFailure
 		}

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -73,7 +73,7 @@ func (p *pushCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcomma
 		slog.Info("Pushing file", slog.String(loggingKeyFile, homeDotPath))
 
 		// Copy the file from the repository to the home directory.
-		if err := copyFile(repoDot, homeDotPath); err != nil {
+		if err := copyFile(repoDot, homeDotPath); err != nil { // nolint:revive // This is valid and traditional error handling
 			slog.Error("Error copying file", slog.String(loggingKeyError, err.Error()))
 			return subcommands.ExitFailure
 		}

--- a/consts.go
+++ b/consts.go
@@ -1,6 +1,7 @@
 package main
 
 const (
-	loggingKeyError = "error"
-	loggingKeyFile  = "file"
+	loggingKeyError  = "error"
+	loggingKeyFile   = "file"
+	loggingKeySignal = "signal"
 )

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 		got := <-sig
-		slog.Info("Received signal, shutting down", slog.String("signal", got.String()))
+		slog.Info("Received signal, shutting down", slog.String(loggingKeySignal, got.String()))
 		cancel()
 	}()
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to improve logging consistency and error handling in the `cmd_pull.go`, `cmd_push.go`, `consts.go`, and `main.go` files. The most important changes include adding a new logging key for signals and updating the logging statements to use this new key.

Improvements to logging:

* [`consts.go`](diffhunk://#diff-f0067949ae0f48685cd310e00ccaf0c72d02048ccc6aeb0a862cd30b81e5e566R6): Added a new constant `loggingKeySignal` for logging signal-related messages.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L35-R35): Updated the logging statement to use the new `loggingKeySignal` constant when logging received signals.

Error handling updates:

* [`cmd_pull.go`](diffhunk://#diff-bc71d63ec325f5efa2edd9badebe7453e633e9578396c9bce15d30b281f41cc4L75-R75): Added a `nolint:revive` comment to the error handling line to indicate that the current error handling method is valid and traditional.
* [`cmd_push.go`](diffhunk://#diff-93042b7fa179061ac6c82160bfd3a0bbd320852439d1e7568699b9d459eddc61L76-R76): Added a `nolint:revive` comment to the error handling line to indicate that the current error handling method is valid and traditional.