### PR TITLE
chore(cicd): Adding adidtional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,8 @@ linters:
     - thelper
     - tparallel
     - intrange
+    - testifylint
+    - perfsprint
 issues:
   exclude-rules:
     - path: (.+)_test.go
@@ -142,3 +144,5 @@ linters-settings:
     enable:
       - identical # Identifies interfaces in the same package that have identical method sets.
       - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+  testifylint:
+    enable-all: true


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes updates to the `.golangci.yaml` configuration file to enhance the linting process by adding new linters and configuring their settings.

Enhancements to linting process:

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R16-R17): Added `testifylint` and `perfsprint` linters to the list of enabled linters.
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R147-R148): Configured `testifylint` to enable all its checks.