### PR TITLE
chore(files): easy file access

### DIFF
--- a/dotfiles.go
+++ b/dotfiles.go
@@ -28,25 +28,15 @@ func getRepositoryDotFiles() ([]string, error) {
 func copyFile(src, dst string) error {
 	fmt.Println("Copying", src, "to", dst)
 
-	srcFile, err := os.Open(src)
+	srcFile, err := os.OpenFile(src, os.O_RDONLY, 0o400)
 	if err != nil {
 		return fmt.Errorf("error opening source file: %w", err)
 	}
-	defer func() {
-		if err := srcFile.Close(); err != nil {
-			fmt.Printf("Error closing source file: %s\n", err)
-		}
-	}()
 
-	dstFile, err := os.Create(dst)
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0o500)
 	if err != nil {
-		return fmt.Errorf("error creating destination file: %w", err)
+		return fmt.Errorf("error opening destination file: %w", err)
 	}
-	defer func() {
-		if err := dstFile.Close(); err != nil {
-			fmt.Printf("Error closing destination file: %s\n", err)
-		}
-	}()
 
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {

--- a/file_selector.go
+++ b/file_selector.go
@@ -27,18 +27,15 @@ func (m *fileSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "q", "esc":
 			return m, tea.Quit
-
 		case "enter":
 			// Send the choice on the channel and exit.
 			m.choice = m.choices[m.cursor]
 			return m, tea.Quit
-
 		case "down", "j":
 			m.cursor++
 			if m.cursor >= len(m.choices) {
 				m.cursor = 0
 			}
-
 		case "up", "k":
 			m.cursor--
 			if m.cursor < 0 {
@@ -46,7 +43,6 @@ func (m *fileSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	}
-
 	return m, nil
 }
 
@@ -55,16 +51,16 @@ func (m *fileSelector) View() string {
 	s.WriteString(m.title + "\n\n")
 
 	for i := range len(m.choices) {
+		str := "( ) "
 		if m.cursor == i {
-			s.WriteString("(•) ")
-		} else {
-			s.WriteString("( ) ")
+			str = "(•) "
 		}
+		s.WriteString(str)
 		s.WriteString(m.choices[i])
 		s.WriteString("\n")
 	}
-	s.WriteString("\n(press q to quit)\n")
 
+	s.WriteString("\n(press q to quit)\n")
 	return s.String()
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -16,25 +16,15 @@ func isGitRepo() bool {
 }
 
 func getDiff(repoDotPath, homeDotPath string) (string, error) {
-	repoContent, err := os.Open(repoDotPath)
+	repoContent, err := os.OpenFile(repoDotPath, os.O_RDONLY, 0o400)
 	if err != nil {
-		return "", fmt.Errorf("error reading repository dotfile: %w", err)
+		return "", fmt.Errorf("error opening file: %w", err)
 	}
-	defer func() {
-		if err := repoContent.Close(); err != nil {
-			slog.Warn("Error closing repository dotfile", slog.String(loggingKeyError, err.Error()))
-		}
-	}()
 
-	homeContent, err := os.Open(homeDotPath)
+	homeContent, err := os.OpenFile(homeDotPath, os.O_RDONLY, 0o400)
 	if err != nil {
-		return "", fmt.Errorf("error reading home dotfile: %w", err)
+		return "", fmt.Errorf("error opening file: %w", err)
 	}
-	defer func() {
-		if err := homeContent.Close(); err != nil {
-			slog.Warn("Error closing home dotfile", slog.String(loggingKeyError, err.Error()))
-		}
-	}()
 
 	diff := difflib.UnifiedDiff{
 		A:       difflib.SplitLines(readFile(repoContent)),


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to improve file handling and code readability. The most important changes involve using `os.OpenFile` for better file permissions and removing unnecessary `defer` statements for closing files.

### File handling improvements:
* [`dotfiles.go`](diffhunk://#diff-1bc8c20d9863ab66af5e9fb9ae84a946e3365269068fee6becd1709e6196df12L31-L49): Changed `os.Open` to `os.OpenFile` with read-only permissions for source files and write permissions for destination files, and removed unnecessary `defer` statements for closing files.
* [`helpers.go`](diffhunk://#diff-296a01a801f363652ec765418086e861f5db0287df573d54c8fde4eebe0e26e9L19-L37): Updated to use `os.OpenFile` with read-only permissions and removed unnecessary `defer` statements for closing files.

### Code readability improvements:
* [`file_selector.go`](diffhunk://#diff-a8d70cf51f02d82a5997d68e0be45626a05953ada70b7c7f081d77777c4d7a1bL30-L49): Removed unnecessary blank lines in the `Update` method.
* [`file_selector.go`](diffhunk://#diff-a8d70cf51f02d82a5997d68e0be45626a05953ada70b7c7f081d77777c4d7a1bR54-R63): Simplified the `View` method by using a temporary string variable for cursor selection.