### PR TITLE
feat(cicd): updating type assert linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - intrange
     - testifylint
     - perfsprint
+    - forcetypeassert
 issues:
   exclude-rules:
     - path: (.+)_test.go


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small change to the `.golangci.yaml` file. The change adds the `forcetypeassert` linter to the list of linters.

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R18): Added `forcetypeassert` to the list of linters.